### PR TITLE
Ensure notification channels and patient IDs in alarms

### DIFF
--- a/hooks/useAlarms.ts
+++ b/hooks/useAlarms.ts
@@ -103,7 +103,7 @@ export function useAlarms() {
         location: config.location,
         dateTime: config.dateTime,
         reminderMinutes: config.reminderMinutes || 60,
-        patientProfileId: profile.id,
+        patientProfileId: profile.patientProfileId || profile.id,
       });
 
       // Recargar alarmas
@@ -134,7 +134,7 @@ export function useAlarms() {
         name: config.name,
         dosage: config.dosage,
         snoozeMinutes: config.snoozeMinutes || 10,
-        patientProfileId: profile.id,
+        patientProfileId: profile.patientProfileId || profile.id,
       });
 
       // Recargar alarmas

--- a/screens/Appointments/AppointmentsScreen.tsx
+++ b/screens/Appointments/AppointmentsScreen.tsx
@@ -187,7 +187,8 @@ export default function AppointmentsScreen() {
                 name: data.doctorName,
                 dosage: '',
                 instructions: data.notes,
-                time: t.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+                time: t.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+                patientProfileId: profile?.patientProfileId || profile?.id,
               },
               trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: firstDate },
             });
@@ -201,7 +202,8 @@ export default function AppointmentsScreen() {
                 name: data.doctorName,
                 dosage: '',
                 instructions: data.notes,
-                time: t.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+                time: t.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+                patientProfileId: profile?.patientProfileId || profile?.id,
               },
               trigger: { 
                 type: Notifications.SchedulableTriggerInputTypes.DAILY,
@@ -227,29 +229,31 @@ export default function AppointmentsScreen() {
               await scheduleNotification({
                 title: `Recordatorio de cita: ${data.doctorName}`,
                 body: `Ubicación: ${data.location}`,
-                data: {
-                  kind: 'APPOINTMENT',
-                  refId: apptId,
-                  scheduledFor: firstDate.toISOString(),
-                  name: data.doctorName,
-                  dosage: '',
-                  instructions: data.notes,
-                  time: t.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-                },
+              data: {
+                kind: 'APPOINTMENT',
+                refId: apptId,
+                scheduledFor: firstDate.toISOString(),
+                name: data.doctorName,
+                dosage: '',
+                instructions: data.notes,
+                time: t.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+                patientProfileId: profile?.patientProfileId || profile?.id,
+              },
                 trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: firstDate },
               });
               const id = await scheduleNotification({
                 title: `Recordatorio de cita: ${data.doctorName}`,
                 body: `Ubicación: ${data.location}`,
-                data: {
-                  kind: 'APPOINTMENT',
-                  refId: apptId,
-                  scheduledFor: t.toISOString(),
-                  name: data.doctorName,
-                  dosage: '',
-                  instructions: data.notes,
-                  time: t.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-                },
+              data: {
+                kind: 'APPOINTMENT',
+                refId: apptId,
+                scheduledFor: t.toISOString(),
+                name: data.doctorName,
+                dosage: '',
+                instructions: data.notes,
+                time: t.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+                patientProfileId: profile?.patientProfileId || profile?.id,
+              },
                 trigger: { 
                   type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
                   weekday: day + 1, 
@@ -282,7 +286,8 @@ export default function AppointmentsScreen() {
                 name: data.doctorName,
                 dosage: '',
                 instructions: data.notes,
-                time: base.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+                time: base.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+                patientProfileId: profile?.patientProfileId || profile?.id,
               },
               trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: firstDate },
             });
@@ -296,7 +301,8 @@ export default function AppointmentsScreen() {
                 name: data.doctorName,
                 dosage: '',
                 instructions: data.notes,
-                time: base.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+                time: base.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+                patientProfileId: profile?.patientProfileId || profile?.id,
               },
               trigger: { 
                 type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,


### PR DESCRIPTION
## Summary
- include channelId and timestamped data when scheduling notifications
- add kind and patient profile ID to appointment and snooze alarms
- fix patientProfileId usage in appointment store and hooks
- streamline HomeScreen with proper snooze scheduling, notification navigation, and cleaner quick actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: multiple TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af433e2750832f801772da2f2d3a95