### PR TITLE
feat: Set custom alarm sound for all notifications

### DIFF
--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -90,7 +90,7 @@ export async function requestPermissions() {
           importance: Notifications.AndroidImportance.HIGH,
           vibrationPattern: [0, 250, 500, 250],
           lightColor: '#2563eb',
-          sound: 'default',
+          sound: 'alarm.mp3', // Usar sonido personalizado
           enableVibrate: true,
           enableLights: true,
         });
@@ -138,7 +138,7 @@ export async function scheduleNotification({
         title,
         body,
         data: notificationData,
-        sound: channelId === 'medications' ? 'alarm.mp3' : 'default', // Usar sonido personalizado para medicamentos
+        sound: (channelId === 'medications' || channelId === 'appointments') ? 'alarm.mp3' : 'default', // Usar sonido personalizado para alarmas
         priority: Notifications.AndroidNotificationPriority.HIGH,
         vibrate: [0, 500, 250, 500, 250, 500], // Vibración más intensa para alarmas
         categoryIdentifier: channelId, // Usar categoryIdentifier en lugar de channelId


### PR DESCRIPTION
This commit updates the notification system to ensure all critical alarms (medications and appointments) use the custom `alarm.mp3` sound.

Previously, only medication reminders were updated to use the custom sound. This change extends the functionality to appointment reminders as well.

- Modified `lib/notifications.ts` to set `sound: 'alarm.mp3'` for the 'appointments' notification channel.
- Updated the `scheduleNotification` function to ensure it uses the custom sound for both 'medications' and 'appointments' channel IDs.